### PR TITLE
Fix dot to underscore replacing in query params

### DIFF
--- a/src/Services/Url.php
+++ b/src/Services/Url.php
@@ -42,7 +42,7 @@ final class Url
         $params = [];
         $paramsString = parse_url($url)['query'] ?? null;
         if ($paramsString) {
-            parse_str($paramsString, $params);
+            $params = self::parseStr($paramsString);
             $pathString = str_replace("?$paramsString", '', $pathString);
         }
 
@@ -78,5 +78,19 @@ final class Url
         $paramsString = http_build_query($params);
 
         return $paramsString === '' ? '' : "?$paramsString";
+    }
+
+    /** @return array<int|string, string> */
+    private static function parseStr(string $query): array
+    {
+        $data = preg_replace_callback(
+            '/(?:^|(?<=&))[^=[]+/',
+            static fn ($match) => bin2hex(urldecode($match[0])),
+            $query
+        );
+
+        parse_str($data, $values);
+
+        return array_combine(array_map('hex2bin', array_keys($values)), $values);
     }
 }

--- a/tests/Unit/Services/UrlTest.php
+++ b/tests/Unit/Services/UrlTest.php
@@ -131,6 +131,17 @@ class UrlTest extends TestCase
                     'filter' => 'aa=bb;cc!=d\;d',
                 ],
             ],
+            [
+                URL::API . '/segment5/segment6?operation.id=a&b = c',
+                [
+                    'segment5',
+                    'segment6',
+                ],
+                [
+                    'operation.id' => 'a',
+                    'b ' => ' c',
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
Стандартная функция [parse_str()](https://www.php.net/manual/en/function.parse-str.php) заменяет точки и пробелы в названиях параметров нижним подчёркиванием. Это поведение [нежелательно](https://github.com/evgeek/moysklad/issues/44), фиксим